### PR TITLE
fix: plugin env vars

### DIFF
--- a/esignet-capture-plugin/.gitignore
+++ b/esignet-capture-plugin/.gitignore
@@ -3,3 +3,4 @@ node_modules
 .d2
 src/locales
 build
+.env*

--- a/esignet-capture-plugin/example.env
+++ b/esignet-capture-plugin/example.env
@@ -1,0 +1,5 @@
+# Examples for a .env file - it should be in the same directory as this example
+# (Vite also supports .env.development, .production, .local, etc. modoifiers)
+
+DHIS2_APP_ESIGNET_CLIENT_ID=IIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEArLeYj
+DHIS2_APP_ESIGNET_UI_BASE_URL=https://example.com

--- a/esignet-capture-plugin/src/clientDetails.ts
+++ b/esignet-capture-plugin/src/clientDetails.ts
@@ -2,13 +2,15 @@
 
 // TODO: Clean up this file
 
+const ESIGNET_UI_BASE_URL =
+    process.env.DHIS2_APP_ESIGNET_UI_BASE_URL ?? 'http://localhost:4000'
 const _env_ = {
-    CLIENT_ID: 'IIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEArLeYj',
-    ESIGNET_UI_BASE_URL:
-        process.env.ESIGNET_UI_BASE_URL ?? 'http://localhost:4000',
-    SIGN_IN_BUTTON_PLUGIN_URL: process.env.ESIGNET_UI_BASE_URL
-        ? process.env.ESIGNET_UI_BASE_URL + '/plugins/sign-in-button-plugin.js'
-        : 'http://localhost:4000/plugins/sign-in-button-plugin.js',
+    CLIENT_ID:
+        process.env.DHIS2_APP_ESIGNET_CLIENT_ID ??
+        'IIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEArLeYj',
+    ESIGNET_UI_BASE_URL: ESIGNET_UI_BASE_URL,
+    SIGN_IN_BUTTON_PLUGIN_URL:
+        ESIGNET_UI_BASE_URL + '/plugins/sign-in-button-plugin.js',
 
     // This should work for any location the plugin is running, e.g.
     // 'http://localhost:8080/api/apps/esignet-capture-plugin/plugin.html#userInfo'
@@ -39,6 +41,16 @@ const _env_ = {
     DEFAULT_LANG: 'en',
     FALLBACK_LANG: '%7B%22label%22%3A%22English%22%2C%22value%22%3A%22en%22%7D',
 }
+
+console.log({
+    _env_,
+    baseUrl: process.env.DHIS2_APP_ESIGNET_UI_BASE_URL,
+    baseUrlMeta: import.meta.env.DHIS2_APP_ESIGNET_UI_BASE_URL,
+    metaEnv: import.meta.env,
+    appNameReact: process.env.REACT_APP_DHIS2_APP_NAME,
+    appNameEnv: process.env.DHIS2_APP_NAME,
+    appNameMeta: import.meta.env.DHIS2_APP_NAME,
+})
 
 // method to check non-empty and non-null
 // values, if present then give default value

--- a/esignet-capture-plugin/src/clientDetails.ts
+++ b/esignet-capture-plugin/src/clientDetails.ts
@@ -42,16 +42,6 @@ const _env_ = {
     FALLBACK_LANG: '%7B%22label%22%3A%22English%22%2C%22value%22%3A%22en%22%7D',
 }
 
-console.log({
-    _env_,
-    baseUrl: process.env.DHIS2_APP_ESIGNET_UI_BASE_URL,
-    baseUrlMeta: import.meta.env.DHIS2_APP_ESIGNET_UI_BASE_URL,
-    metaEnv: import.meta.env,
-    appNameReact: process.env.REACT_APP_DHIS2_APP_NAME,
-    appNameEnv: process.env.DHIS2_APP_NAME,
-    appNameMeta: import.meta.env.DHIS2_APP_NAME,
-})
-
 // method to check non-empty and non-null
 // values, if present then give default value
 const checkEmptyNullValue = (initialValue, defaultValue) =>


### PR DESCRIPTION
To point the app to a particular esignet UI, you can add a `.env` file inside `esignet-capture-plugin` with contents like:

```.env
DHIS2_APP_ESIGNET_CLIENT_ID=IIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEArLeYj
DHIS2_APP_ESIGNET_UI_BASE_URL=https://example.com
```

Then build and deploy the plugin