### PR TITLE
fix: plugin shrinking bug on Windows

### DIFF
--- a/esignet-capture-plugin/src/Plugin.tsx
+++ b/esignet-capture-plugin/src/Plugin.tsx
@@ -2,17 +2,16 @@
 import { CssVariables } from '@dhis2/ui'
 import React, { FC } from 'react'
 import { HashRouter, Routes, Route, Outlet } from 'react-router'
-import classes from './App.module.css'
 import { FormField } from './plugin/FormField'
 import { RedirectHandler } from './plugin/RedirectHandler'
 import { IDataEntryPluginProps } from './Plugin.types'
 import './locales'
 
 const Layout: FC = () => (
-    <div className={classes.container}>
+    <>
         <CssVariables colors />
         <Outlet />
-    </div>
+    </>
 )
 
 const Plugin = (pluginProps: IDataEntryPluginProps) => {

--- a/esignet-capture-plugin/src/plugin/FormField.module.css
+++ b/esignet-capture-plugin/src/plugin/FormField.module.css
@@ -2,9 +2,6 @@
     display: flex;
     padding: 8px 8px 8px 12px;
     width: 100%;
-    /* This... for some reason fixes an issue in Windows where the plugin
-    will hit a resize loop and shrink to it's minimum size: */
-    border: 1px solid transparent;
 }
 
 .labelContainer {
@@ -40,4 +37,10 @@
 :global(.app-shell-app) {
     background-color: #fbfcfd;
     border-block-end: 1px solid #e8edf2;
+}
+
+/* This... for some reason fixes an issue in Windows where the plugin
+   will hit a resize loop and shrink to it's minimum size: */
+:global(#resizeDiv > *) {
+    border: 1px solid transparent;
 }

--- a/esignet-capture-plugin/src/plugin/FormField.module.css
+++ b/esignet-capture-plugin/src/plugin/FormField.module.css
@@ -2,13 +2,13 @@
     display: flex;
     padding: 8px 8px 8px 12px;
     width: 100%;
+    /* This... for some reason fixes an issue in Windows where the plugin
+    will hit a resize loop and shrink to it's minimum size: */
+    border: 1px solid transparent;
 }
 
 .labelContainer {
     padding: 8px 16px 4px 4px;
-    flex-grow: 0;
-    flex-shrink: 0;
-    flex-basis: 200px;
     /* Match sizing of other Capture fields */
     min-width: 40%;
 }


### PR DESCRIPTION
Fixes [INTEROP-90](https://dhis2.atlassian.net/browse/INTEROP-90)

A weird fix for a weird phenomenon 🤔
(Already fixed on the demo branch)

Before:
<img width="738" height="350" alt="shrinking-plugin" src="https://github.com/user-attachments/assets/db70eb29-c236-4423-94b4-fee88c53d189" />

After:
<img width="781" height="265" alt="plugin-regular" src="https://github.com/user-attachments/assets/c9cfab9d-ded3-4e87-b996-88c474cd19a4" />



[INTEROP-90]: https://dhis2.atlassian.net/browse/INTEROP-90?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ